### PR TITLE
pymc 5.16.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:  
-  - https://staging.continuum.io/prefect/fs/pytensor-feedstock/pr4/7eb3040

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:  
+  - https://staging.continuum.io/prefect/fs/pytensor-feedstock/pr4/7eb3040

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,8 +59,8 @@ test:
 
 about:
   home: https://www.pymc.io/welcome.html
-  license: Apache-2.0
-  license_family: Apache
+  license: Apache-2.0 AND MIT
+  license_family: OTHER
   license_file: LICENSE
   summary: 'PyMC: Bayesian Stochastic Modelling in Python'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
-    #- {{ compiler('gcc')}}
   host:
     - python
     - pip
@@ -38,7 +37,7 @@ requirements:
     - scipy <1.13
     - rich >=13.7.1
     - typing-extensions >=3.7.4
-    - threadpoolctl>=3.1.0,<4.0.0
+    - threadpoolctl >=3.1.0,<4.0.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,8 @@ requirements:
     - fastprogress >=0.2.0
     - pandas >=0.24.0
     - pytensor >=2.23,<2.24
-    - scipy <1.4.1
+      # Reverting scipy to <1.13 due to pymc import failure that was caused due to older version of arviz
+    - scipy <1.13
     - rich >=13.7.1
     - typing-extensions >=3.7.4
     - threadpoolctl>=3.1.0,<4.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pandas >=0.24.0
     - pytensor >=2.23,<2.24
       # Reverting scipy to <1.13 due to pymc import failure that was caused due to older version of arviz
-    - scipy <1.13
+    - scipy >=1.4.1,<1.13
     - rich >=13.7.1
     - typing-extensions >=3.7.4
     - threadpoolctl >=3.1.0,<4.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.6.1" %}
+{% set version = "5.16.1" %}
 {% set name = "pymc" %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://github.com/pymc-devs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 3445f91136e44fe02a3e5029b2ececd262bc6623d4622c02cc47da21fa634be2
+  sha256: 00eff0ccc7c06029aab2c580524f101e922315d3937a82d116b842065a120847
 
 build:
   number: 0
   # skip because arviz is not supported for py38
-  skip: True  # [py<39]
+  skip: True  # [py<=310]
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
 
@@ -20,6 +20,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
+    - {{ compiler('gcc')}}
   host:
     - python
     - pip
@@ -33,11 +34,15 @@ requirements:
     - cloudpickle
     - fastprogress >=0.2.0
     - pandas >=0.24.0
-    - pytensor >=2.12.0,<2.13
-    - scipy >=1.4.1
+    - pytensor >=2.23,<2.24
+    - scipy <1.4.1
+    - rich >=13.7.1
     - typing-extensions >=3.7.4
+    - threadpoolctl>=3.1.0,<4.0.0
 
 test:
+  source_files:
+    - tests
   imports:
     - pymc
     - pymc.backends

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - arviz >=0.13.0
     - cachetools >=4.2.1
     - cloudpickle
-    - fastprogress >=0.2.0
     - pandas >=0.24.0
     - pytensor >=2.23,<2.24
       # Reverting scipy to <1.13 due to pymc import failure that was caused due to older version of arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
-    - {{ compiler('gcc')}}
+    #- {{ compiler('gcc')}}
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  # skip because arviz is not supported for py38
   skip: True  # [py<=310]
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
@@ -55,8 +54,10 @@ test:
     - pymc.ode
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests/model/test_core.py
 
 about:
   home: https://www.pymc.io/welcome.html


### PR DESCRIPTION
pymc 5.16.1 

**Destination channel:** Defaults

### Links

- [PKG-5095]
- dev_url:        https://github.com/pymc-devs/pymc/tree/v5.16.1
- conda_forge:    https://github.com/conda-forge/pymc-feedstock
- pypi:           https://pypi.org/project/pymc/5.16.1
- pypi inspector: https://inspector.pypi.io/project/pymc/5.16.1/

### Explanation of changes:

- Reverting scipy to <1.13 due to pymc import failure that was caused due to older version of arviz. In the future, it could be worth updating arviz to solve the issue. See: https://github.com/pymc-devs/pymc/issues/7236
- Adding tests, and running tests form one file like documentation mentions. Otherwise tests would take a lot of time. See: https://www.pymc.io/projects/docs/en/latest/contributing/running_the_test_suite.html


[PKG-5095]: https://anaconda.atlassian.net/browse/PKG-5095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ